### PR TITLE
Fix infinite loop on `Seek()` method

### DIFF
--- a/imgserver.go
+++ b/imgserver.go
@@ -662,7 +662,7 @@ func (b *efsFileBody) Close() error {
 func (b *efsFileBody) Seek(offset int64, whence int) (int64, error) {
 	seek := func() (int64, error) {
 		b.currOffset = offsetUncontrolled
-		return b.Seek(offset, whence)
+		return b.body.Seek(offset, whence)
 	}
 
 	switch b.currOffset {


### PR DESCRIPTION
Fix infinite loop on `Seek()` method #31